### PR TITLE
conan: Only use the os for header only libraries

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -1,5 +1,6 @@
 from conans import ConanFile
 
+
 class SPIRVHeadersConan(ConanFile):
     name = "SPIRV-Headers"
     version = "0.0.1"
@@ -7,8 +8,8 @@ class SPIRVHeadersConan(ConanFile):
     license = "https://github.com/Esri/SPIRV-Headers/blob/runtimecore/LICENSE"
     description = "Machine-readable files for the SPIR-V Registry"
 
-    # RTC specific triple
-    settings = "platform_architecture_target"
+    # Use the OS default to get the right line endings
+    settings = "os"
 
     def package(self):
         base = self.source_folder


### PR DESCRIPTION
This will reduce the duplication of packages that are set for every arch.